### PR TITLE
prevent updating progress if item is marked as watched

### DIFF
--- a/Jellyfin.Plugin.MediaTracker/ServerEntryPoint.cs
+++ b/Jellyfin.Plugin.MediaTracker/ServerEntryPoint.cs
@@ -184,30 +184,6 @@ public class ServerEntryPoint : IServerEntryPoint
                     continue;
                 }
 
-                logger.LogInformation("Updating progress for episode of {0} S{1:00}E{2:00} - {3:0.00}% - {4} for user {5}",
-                    episode.SeriesName,
-                    seasonNumber,
-                    episodeNumber,
-                    progress * 100,
-                    action,
-                    user.Username);
-
-                await UpdateProgress(user, new
-                {
-                    mediaType = "tv",
-                    id = new
-                    {
-                        imdbId = imdbId,
-                        tmdbId = tmdbId
-                    },
-                    seasonNumber = seasonNumber,
-                    episodeNumber = episodeNumber,
-                    action = action,
-                    progress = progress,
-                    duration = durationInMilliseconds,
-                    device = deviceName
-                });
-
                 if (progress > minimumProgressToMarkAsSeen && progressDictionary.CanMarkAsSeen(user, episode))
                 {
                     logger.LogInformation("Adding episode of {0} S{1:00}E{2:00} to seen history for user {3}",
@@ -227,6 +203,32 @@ public class ServerEntryPoint : IServerEntryPoint
                         seasonNumber = seasonNumber,
                         episodeNumber = episodeNumber,
                         duration = durationInMilliseconds,
+                    });
+                }
+                else
+                {
+                    logger.LogInformation("Updating progress for episode of {0} S{1:00}E{2:00} - {3:0.00}% - {4} for user {5}",
+                        episode.SeriesName,
+                        seasonNumber,
+                        episodeNumber,
+                        progress * 100,
+                        action,
+                        user.Username);
+    
+                    await UpdateProgress(user, new
+                    {
+                        mediaType = "tv",
+                        id = new
+                        {
+                            imdbId = imdbId,
+                            tmdbId = tmdbId
+                        },
+                        seasonNumber = seasonNumber,
+                        episodeNumber = episodeNumber,
+                        action = action,
+                        progress = progress,
+                        duration = durationInMilliseconds,
+                        device = deviceName
                     });
                 }
             }


### PR DESCRIPTION
Disclaimer: I have not tested these changes. I can try to test these changes if you tell me this is a wanted PR, I just haven't set anything up yet.

I really appreciate both MediaTracker and this plugin, thank you for all your work.

I've noticed that the plugin seems to not work as intended. When I 100% watch a movie on Jellyfin, the corresponding entry on MediaTracker is marked as watched AND the progress is set to 100%. This means that even though the movie has been marked as watched, the progress bar still shows up, as if I was still watching the movie. I can click on the button "I finished watching it" to get rid of the progress bar, but this then adds a second "seen" entry. This seems unintended and undesirable, and is in fact not how TV episodes behave (TV episodes simply get marked as watched).

So, I'm suggesting these changes. Let me know what you think.