### PR TITLE
refactor PreviousActions

### DIFF
--- a/Jellyfin.Plugin.MediaTracker/ServerEntryPoint.cs
+++ b/Jellyfin.Plugin.MediaTracker/ServerEntryPoint.cs
@@ -102,7 +102,7 @@ public class ServerEntryPoint : IHostedService, IDisposable
 
     private async void OnPlaybackChanged(PlaybackProgressEventArgs e, string action)
     {
-        if (e.Users == null || !e.Users.Any())
+        if (e.Users == null || e.Users.Count == 0)
         {
             logger.LogError("Missing users");
             return;
@@ -205,13 +205,13 @@ public class ServerEntryPoint : IHostedService, IDisposable
                     mediaType = "tv",
                     id = new
                     {
-                        imdbId = imdbId,
-                        tmdbId = tmdbId
+                        imdbId,
+                        tmdbId
                     },
-                    seasonNumber = seasonNumber,
-                    episodeNumber = episodeNumber,
-                    action = action,
-                    progress = progress,
+                    seasonNumber,
+                    episodeNumber,
+                    action,
+                    progress,
                     duration = durationInMilliseconds,
                     device = deviceName
                 });
@@ -229,11 +229,11 @@ public class ServerEntryPoint : IHostedService, IDisposable
                         mediaType = "tv",
                         id = new
                         {
-                            imdbId = imdbId,
-                            tmdbId = tmdbId
+                            imdbId,
+                            tmdbId
                         },
-                        seasonNumber = seasonNumber,
-                        episodeNumber = episodeNumber,
+                        seasonNumber,
+                        episodeNumber,
                         duration = durationInMilliseconds,
                     });
                 }
@@ -276,11 +276,11 @@ public class ServerEntryPoint : IHostedService, IDisposable
                     mediaType = "movie",
                     id = new
                     {
-                        imdbId = imdbId,
-                        tmdbId = tmdbId
+                        imdbId,
+                        tmdbId
                     },
-                    action = action,
-                    progress = progress,
+                    action,
+                    progress,
                     duration = durationInMilliseconds,
                     device = deviceName
                 });
@@ -296,8 +296,8 @@ public class ServerEntryPoint : IHostedService, IDisposable
                         mediaType = "movie",
                         id = new
                         {
-                            imdbId = imdbId,
-                            tmdbId = tmdbId
+                            imdbId,
+                            tmdbId
                         },
                         duration = durationInMilliseconds,
                     });
@@ -339,7 +339,6 @@ public class ServerEntryPoint : IHostedService, IDisposable
         var content = new StringContent(payloadJson, System.Text.Encoding.UTF8, "application/json");
 
         var uri = new Uri(new Uri(mediaTrackerUrl), path + "?token=" + apiToken);
-        var httpClient = httpClientFactory.CreateClient();
 
         try
         {

--- a/Jellyfin.Plugin.MediaTracker/src/PreviousActions.cs
+++ b/Jellyfin.Plugin.MediaTracker/src/PreviousActions.cs
@@ -56,8 +56,8 @@ public class PreviousActions
 {
     public PreviousActions()
     {
-        progressDictionary = new Dictionary<Tuple<Guid, Guid>, PreviousAction>();
-        markedAsSeenHistory = new Dictionary<Tuple<Guid, Guid>, DateTime>();
+        progressDictionary = [];
+        markedAsSeenHistory = [];
     }
 
     public void Cleanup()
@@ -71,18 +71,15 @@ public class PreviousActions
     {
         var id = Tuple.Create(user.Id, video.Id);
 
-        PreviousAction? res;
-
-        if (progressDictionary.TryGetValue(id, out res))
+        if (progressDictionary.TryGetValue(id, out PreviousAction? value))
         {
-            if (res.ShouldSkip(action, progress))
+            if (value.ShouldSkip(action, progress))
             {
                 return true;
             }
         }
-
-        progressDictionary.Remove(id);
-        progressDictionary.Add(id, new PreviousAction(action, progress));
+        
+        progressDictionary[id] = new PreviousAction(action, progress);
 
         return false;
     }
@@ -91,9 +88,7 @@ public class PreviousActions
     {
         var id = Tuple.Create(user.Id, video.Id);
 
-        DateTime res;
-
-        if (markedAsSeenHistory.TryGetValue(id, out res))
+        if (markedAsSeenHistory.ContainsKey(id))
         {
             return false;
         }

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "MediaTracker"
 guid: "c4772eae-799e-490d-abff-4de21f99c95e"
-version: 2
+version: "2.0.0.1"
 targetAbi: "10.9.1.0"
 framework: "net8.0"
 overview: "MediaTracker scrobbler"
@@ -11,3 +11,4 @@ owner: "bonukai"
 artifacts:
 - "Jellyfin.Plugin.MediaTracker.dll"
 changelog:
+- "refactored ShouldSkipAction"


### PR DESCRIPTION
replace [remove](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.remove?view=net-8.0) followed by [add](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.add?view=net-8.0) dictionary methods with [indexer](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.item?view=net-8.0), that will not throw, when a key already is in the dictionary, old value will be overwritten. See #9 